### PR TITLE
added bind 9.11

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
 
 <p>Currently <code>dnstap</code> can only encode wire-format DNS messages. It is planned to support additional types of DNS log information.</p>
 
-<p>Server-side <code>dnstap</code> support is included in the <a href="https://www.knot-dns.cz/">Knot DNS</a> authoritative nameserver as of <a href="https://lists.nic.cz/pipermail/knot-dns-users/2014-July/000477.html">version 1.5.0</a> and in the <a href="http://unbound.net/">Unbound</a> recursive DNS server as of <a href="http://www.unbound.net/pipermail/unbound-users/2014-November/003620.html">version 1.5.0</a>. It is planned to develop <code>dnstap</code> support for additional DNS servers and other kinds of DNS software.</p>
+<p>Server-side <code>dnstap</code> support is included in the <a href="https://www.knot-dns.cz/">Knot DNS</a> authoritative nameserver as of <a href="https://lists.nic.cz/pipermail/knot-dns-users/2014-July/000477.html">version 1.5.0</a> and in the <a href="http://unbound.net/">Unbound</a> recursive DNS server as of <a href="http://www.unbound.net/pipermail/unbound-users/2014-November/003620.html">version 1.5.0</a> and in upcoming <a href="http://www.isc.org/">Bind</a> as of <a href="https://kb.isc.org/article/AA-01409/81/BIND-9.11.0rc1-Release-Notes.html">version 9.11</a>. It is planned to develop <code>dnstap</code> support for additional DNS servers and other kinds of DNS software.</p>
 
 <p>A standalone command-line tool for receiving and decoding <code>dnstap</code> log messages is also being worked on. Check out <a href="https://gist.github.com/edmonds/5772879">this example output</a> from the <code>dnstap</code> command to get an idea of the kind of information that <code>dnstap</code> can encode.</p>
 


### PR DESCRIPTION
bind 9.11 is going to support dnstap see https://kb.isc.org/article/AA-01409/81/BIND-9.11.0rc1-Release-Notes.html
Added support for dnstap, a fast, flexible method for capturing and logging DNS traffic, developed by Robert Edmonds at Farsight Security, Inc., whose assistance is gratefully acknowledged.
