### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,6 +88,7 @@
 <li><p><a href="http://unbound.net/">Unbound</a> as of <a href="http://www.unbound.net/pipermail/unbound-users/2014-November/003620.html">version 1.5.0</a></p></li>
 <li><p><a href="https://www.isc.org/downloads/bind/">BIND</a> as of <a href="https://kb.isc.org/article/AA-01342/0/Using-DNSTAP-with-BIND-9.11.html">version 9.11</a></p></li>
 <li><p><a href="https://www.knot-resolver.cz/">Knot Resolver</a> as of <a href="https://www.knot-resolver.cz/2017-04-05-knot-resolver-1.2.5.html">version 1.2.5</a></p></li>
+<li><p><a href="https://coredns.io/plugins/dnstap/">CoreDNS</a> as of <a href="https://github.com/coredns/coredns/releases/tag/v1.5.0">version 1.5.0</a></p></li>
 </ul>
 
 


### PR DESCRIPTION
CoreDNS supports dnstap, too.  It definitely supports it in the current version, 1.5.0, but has for a few releases prior.